### PR TITLE
Mean and variance

### DIFF
--- a/__tests__/Distributions__Test.re
+++ b/__tests__/Distributions__Test.re
@@ -13,16 +13,15 @@ let makeTest = (~only=false, str, item1, item2) =>
       );
 
 let makeTestCloseEquality = (~only=false, str, item1, item2, ~digits) =>
-only
-  ? Only.test(str, () =>
-      expect(item1) |> toBeSoCloseTo(item2, ~digits)
-    )
-  : test(str, () =>
-      expect(item1) |> toBeSoCloseTo(item2, ~digits)
-    );
+  only
+    ? Only.test(str, () =>
+        expect(item1) |> toBeSoCloseTo(item2, ~digits)
+      )
+    : test(str, () =>
+        expect(item1) |> toBeSoCloseTo(item2, ~digits)
+      );
 
 describe("Shape", () => {
-  
   describe("Continuous", () => {
     open Distributions.Continuous;
     let continuous = make(`Linear, shape);
@@ -129,7 +128,7 @@ describe("Shape", () => {
       1.0,
     );
   });
-  
+
   describe("Discrete", () => {
     open Distributions.Discrete;
     let shape: DistTypes.xyShape = {
@@ -195,7 +194,13 @@ describe("Shape", () => {
       0.9,
     );
     makeTest("integralEndY", T.Integral.sum(~cache=None, discrete), 1.0);
-
+    makeTest("mean", T.getMean(discrete), 3.9);
+    makeTestCloseEquality(
+      "variance",
+      T.getVariance(discrete),
+      5.89,
+      ~digits=7,
+    );
   });
 
   describe("Mixed", () => {
@@ -300,7 +305,6 @@ describe("Shape", () => {
         },
       ),
     );
-  
   });
 
   describe("Distplus", () => {
@@ -380,33 +384,36 @@ describe("Shape", () => {
     let stdev = 4.0;
     let variance = stdev ** 2.0;
     let numSamples = 10000;
-
     open Distributions.Shape;
-    let normal: SymbolicDist.dist = `Normal({ mean, stdev});
+    let normal: SymbolicDist.dist = `Normal({mean, stdev});
     let normalShape = SymbolicDist.GenericSimple.toShape(normal, numSamples);
     let lognormal = SymbolicDist.Lognormal.fromMeanAndStdev(mean, stdev);
-    let lognormalShape = SymbolicDist.GenericSimple.toShape(lognormal, numSamples);
+    let lognormalShape =
+      SymbolicDist.GenericSimple.toShape(lognormal, numSamples);
 
     makeTestCloseEquality(
       "Mean of a normal",
-      T.getMean(normalShape), 
-      mean, 
-      ~digits=2);
+      T.getMean(normalShape),
+      mean,
+      ~digits=2,
+    );
     makeTestCloseEquality(
-      "Variance of a normal", 
-      T.getVariance(normalShape), 
-      variance, 
-      ~digits=1);
+      "Variance of a normal",
+      T.getVariance(normalShape),
+      variance,
+      ~digits=1,
+    );
     makeTestCloseEquality(
-      "Mean of a lognormal", 
-      T.getMean(lognormalShape), 
-      mean, 
-      ~digits=2);
+      "Mean of a lognormal",
+      T.getMean(lognormalShape),
+      mean,
+      ~digits=2,
+    );
     makeTestCloseEquality(
-      "Variance of a lognormal", 
-      T.getVariance(lognormalShape), 
-      variance, 
-      ~digits=0);
+      "Variance of a lognormal",
+      T.getVariance(lognormalShape),
+      variance,
+      ~digits=0,
+    );
   });
-
 });

--- a/src/distPlus/distribution/XYShape.re
+++ b/src/distPlus/distribution/XYShape.re
@@ -298,3 +298,56 @@ let logScorePoint = (sampleCount, t1, t2) =>
   |> E.O.fmap(T.accumulateYs((+.)))
   |> E.O.fmap(Pairs.last)
   |> E.O.fmap(Pairs.y);
+
+
+module Analysis = { 
+  let integrateContinuousShape = (
+    ~indefiniteIntegralStepwise = (p,h1) => (h1*.(p**2.0)/. 2.0), 
+    ~indefiniteIntegralLinear = (p, a, b) => (a *. (p ** 2.0) /.2.0) +. (b *. (p**3.0) /. 3.0),
+    t: DistTypes.continuousShape
+    ): float => {
+    let xs = t.xyShape.xs;
+    let ys = t.xyShape.ys;
+
+    E.A.reducei(xs, 0.0, (acc, _x, i) => {          
+      let areaUnderIntegral = switch(t.interpolation, i){
+        | (_, 0) => 0.0;
+        | (`Stepwise, _) => indefiniteIntegralStepwise(xs[i],ys[i-1]) 
+          -. indefiniteIntegralStepwise(xs[i-1],ys[i-1]);
+        | (`Linear, _) => {
+          let x1 = xs[i-1];
+          let x2 = xs[i];
+          let h1 = ys[i-1];
+          let h2 = ys[i];
+          let b = (h1 -. h2 ) /. (x1 -.x2)
+          let a = h1 -. b *.x1;
+          indefiniteIntegralLinear(x2, a, b) -. indefiniteIntegralLinear(x1, a, b);
+          };
+      };
+      acc +. areaUnderIntegral;
+    });
+  };
+  let getVarianceDangerously =  (
+    t: 't, 
+    getMean: ('t => float), 
+    getMeanOfSquares: ('t => float), 
+  ): float => {
+
+    let meanSquared = getMean(t)**2.0; 
+    let meanOfSquares = getMeanOfSquares(t);
+
+    meanOfSquares -. meanSquared;
+  };
+  
+  let squareXYShape = t: DistTypes.xyShape => {...t, xs: E.A.fmap(x => x**2.0, t.xs)};
+
+  let getMeanOfSquaresContinuousShape = (t: DistTypes.continuousShape) => {
+    let indefiniteIntegralLinear = (p, a, b) => (a *. (p ** 3.0) /.3.0) +. (b *. (p**4.0) /. 4.0);
+    let indefiniteIntegralStepwise = (p,h1) => h1*.(p**3.0)/. 3.0;  
+    integrateContinuousShape(
+      ~indefiniteIntegralStepwise,
+      ~indefiniteIntegralLinear,
+      t
+    );
+  }
+};

--- a/src/distPlus/utility/E.re
+++ b/src/distPlus/utility/E.re
@@ -259,6 +259,9 @@ module A = {
   let fold_right = Array.fold_right;
   let concatMany = Belt.Array.concatMany;
   let keepMap = Belt.Array.keepMap;
+  let init = Array.init;
+  let reduce = Belt.Array.reduce;
+  let reducei = Belt.Array.reduceWithIndex;
   let min = a =>
     get(a, 0)
     |> O.fmap(first => Belt.Array.reduce(a, first, (i, j) => i < j ? i : j));


### PR DESCRIPTION
- A getMean and getVariance in each module of src/distPlus/distribution/Distributions.re
    - They get the exact answer for the functions in Distributions.re, according to the approximation used.
    - There is now an XYShape.Analysis.integrateContinuousShape function.
- Tests in the __tests__/Distributions__Test.re function.
    - Calculation of the mean and variance for the normal and lognnormal distributions, at the end.
- I also added some reduce array functions to the E.A. module.