### PR TITLE
Makes four opinionated changes which improve my user experience:

### DIFF
--- a/src/components/DistBuilder.re
+++ b/src/components/DistBuilder.re
@@ -170,7 +170,7 @@ let make = () => {
       ~schema,
       ~onSubmit=({state}) => {None},
       ~initialState={
-        guesstimatorString: "40 to 8000",
+        guesstimatorString: "mm(normal(10, 2), uniform(16, 20), normal(15,1))",
         domainType: "Complete",
         xPoint: "50.0",
         xPoint2: "60.0",

--- a/src/components/charts/DistPlusPlot.re
+++ b/src/components/charts/DistPlusPlot.re
@@ -250,7 +250,7 @@ module DistPlusChart = {
       yMaxContinuousDomainFactor
       ?discrete
       ?continuous
-      color={`hex("5f6b7e")}
+      color={`hex("1894d6")}
       onHover
       timeScale
     />;
@@ -277,7 +277,7 @@ module IntegralChart = {
       minX
       maxX
       ?continuous
-      color={`hex("5f6b7e")}
+      color={`hex("1894d6")}
       timeScale
       onHover
     />;

--- a/src/components/charts/DistPlusPlotReducer.re
+++ b/src/components/charts/DistPlusPlotReducer.re
@@ -30,10 +30,12 @@ let changeHeight = (currentHeight, foo: [ | `increment | `decrement]) =>
   | (2, `decrement) => 1
   | (3, `decrement) => 2
   | (4, `decrement) => 3
+  | (5, `decrement) => 4
   | (1, `increment) => 2
   | (2, `increment) => 3
   | (3, `increment) => 4
-  | (4, `increment) => 4
+  | (4, `increment) => 5
+  | (5, `increment) => 5
   | _ => 1
   };
 
@@ -43,6 +45,7 @@ let heightToPix =
   | 2 => 140
   | 3 => 240
   | 4 => 340
+  | 5 => 440
   | _ => 140;
 
 let distributionReducer = (index, state: list(chartConfig), action) => {
@@ -69,7 +72,7 @@ let distributionReducer = (index, state: list(chartConfig), action) => {
   | (ADD_DIST, Some(_)) =>
     E.L.append(
       state,
-      [{yLog: false, xLog: false, isCumulative: false, height: 2}],
+      [{yLog: false, xLog: false, isCumulative: false, height: 4}],
     )
   | _ => state
   };
@@ -103,7 +106,6 @@ let init = {
   showParams: false,
   showPercentiles: true,
   distributions: [
-    {yLog: false, xLog: false, isCumulative: false, height: 2},
-    {yLog: false, xLog: false, isCumulative: true, height: 1},
+    {yLog: false, xLog: false, isCumulative: false, height: 4},
   ],
 };


### PR DESCRIPTION
- Makes the distributions bigger, much bigger, so that I can better see them.
    - I add another height level, 5 (440px) and make 4 (340px) the default.
- To do that, and to be able to see the input string at the same time I destroy the cdf.
    - My brain wasn't really made for interpreting cdfs, and I can switch to the cdf view if I want.
    - Note that this destroys the pdf + cdf combo as as default everywhere.
- Changes the distribution color to a bright, happy and shiny blue, so that I can better see them.
- Adds a standard distribution with more personality.

Before:
![before](https://user-images.githubusercontent.com/16527456/79699256-9ed5cc80-828e-11ea-8e92-5f1703836eef.png)

After:
![after](https://user-images.githubusercontent.com/16527456/79699243-8a91cf80-828e-11ea-96fb-b2cf638e0447.png)
